### PR TITLE
Feature browse paging

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,9 +13,9 @@ auth.init(app);
 app.get('/browse', async (req, res) => {
     let page = req.query.page ? parseInt(req.query.page) : 1;
     const limit = req.query.limit ? parseInt(req.query.limit) : 10;
-    let skip = (page - 1) * limit;
-    const posts = await postManager.getPosts();
-    const total = posts.length;
+    let offset = (page - 1) * limit;
+    const posts = await postManager.getPosts(limit, offset);
+    const total = await postManager.getPostsTotal();
     res.render('browse', { posts: posts, page: 0, total: total });
 });
 

--- a/index.js
+++ b/index.js
@@ -1,7 +1,6 @@
 const express = require('express');
 const auth = require('./auth');
 const postManager = require('./postManager');
-const db = require('./firebase');
 const app = express();
 const port = 8080;
 

--- a/index.js
+++ b/index.js
@@ -11,8 +11,12 @@ auth.init(app);
 
 
 app.get('/browse', async (req, res) => {
+    let page = req.query.page ? parseInt(req.query.page) : 1;
+    const limit = req.query.limit ? parseInt(req.query.limit) : 10;
+    let skip = (page - 1) * limit;
     const posts = await postManager.getPosts();
-    res.render('browse', { posts });
+    const total = posts.length;
+    res.render('browse', { posts: posts, page: 0, total: total });
 });
 
 app.get('/createPost', (req, res) => res.render('createPost'));

--- a/index.js
+++ b/index.js
@@ -16,7 +16,7 @@ app.get('/browse', async (req, res) => {
     let offset = (page - 1) * limit;
     const posts = await postManager.getPosts(limit, offset);
     const total = await postManager.getPostsTotal();
-    res.render('browse', { posts: posts, page: 0, total: total });
+    res.render('browse', { posts: posts, page: page, limit:limit, total: total });
 });
 
 app.get('/createPost', (req, res) => res.render('createPost'));

--- a/postManager.js
+++ b/postManager.js
@@ -22,7 +22,7 @@ const handleCreatePost = async (req, res) => {
 }
 
 const getPosts = async () => {
-    const snapshot = await db.collection('posts').get();
+    const snapshot = await db.collection('posts').orderBy('unixTime', 'desc').get();
     return snapshot.docs.map(doc => doc.data());
 }
 

--- a/postManager.js
+++ b/postManager.js
@@ -21,14 +21,20 @@ const handleCreatePost = async (req, res) => {
 	res.redirect('/browse'); // later, this should redirect to the page that views the newly-made post
 }
 
-const getPosts = async () => {
-    const snapshot = await db.collection('posts').orderBy('unixTime', 'desc').get();
+const getPosts = async (limit, offset) => {
+    const snapshot = await db.collection('posts').orderBy('unixTime', 'desc').limit(limit).offset(offset).get();
     return snapshot.docs.map(doc => doc.data());
+}
+
+const getPostsTotal = async () => {
+    const snapshot = await db.collection('posts').get();
+    return snapshot.size;
 }
 
 module.exports = {
 	handleCreatePost,
 	createPost,
-    getPosts
+    getPosts,
+    getPostsTotal
 };
 

--- a/views/browse.ejs
+++ b/views/browse.ejs
@@ -94,8 +94,13 @@
 
         <h1>Browsing <%= total %> Posts...</h1>
             <ul>
-                <a href="/browse?page=<%= page - 1 %>&limit=10">Previous</a>
-                <a href="/browse?page=<%= page + 1 %>&limit=10">Next</a>
+                <% if (page > 1) { %>
+                    <a href="/browse?page=<%= page - 1 %>&limit=10">Last Page</a>
+                <% } %>
+                <%= page %>
+                <% if (page < (total/limit)) { %>
+                    <a href="/browse?page=<%= page + 1 %>&limit=10">Next Page</a>
+                <% } %>
                 <% for (let i = 0; i < posts.length; i++) { %>
                     <li class="listing-tile">
                         <div class="listing-image">
@@ -108,8 +113,13 @@
                         </div>
                     </li>
                 <% } %>
-                <a href="/browse?page=<%= page - 1 %>&limit=10">Last Page</a>
-                <a href="/browse?page=<%= page + 1 %>&limit=10">Next Page</a>
+                <% if (page > 1) { %>
+                    <a href="/browse?page=<%= page - 1 %>&limit=10">Last Page</a>
+                <% } %>
+                <%= page %>
+                <% if (page < (total/limit)) { %>
+                    <a href="/browse?page=<%= page + 1 %>&limit=10">Next Page</a>
+                <% } %>
             </ul>
 
         <h2 class="f1">

--- a/views/browse.ejs
+++ b/views/browse.ejs
@@ -92,9 +92,11 @@
             </form>
         </nav>
 
-        <h1>Browsing...</h1>
+        <h1>Browsing <%= total %> Posts...</h1>
             <ul>
-                <% for (let i = 0; i < 10 && i < posts.length; i++) { %>
+                <a href="/browse?page=<%= page - 1 %>&limit=10">Previous</a>
+                <a href="/browse?page=<%= page + 1 %>&limit=10">Next</a>
+                <% for (let i = 0; i < posts.length; i++) { %>
                     <li class="listing-tile">
                         <div class="listing-image">
                             <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/c/c2/GitHub_Invertocat_Logo.svg/800px-GitHub_Invertocat_Logo.svg.png" alt="Listing Image">
@@ -106,6 +108,8 @@
                         </div>
                     </li>
                 <% } %>
+                <a href="/browse?page=<%= page - 1 %>&limit=10">Last Page</a>
+                <a href="/browse?page=<%= page + 1 %>&limit=10">Next Page</a>
             </ul>
 
         <h2 class="f1">


### PR DESCRIPTION
The browse page will now only show ten listings at a time, and allow the user to navigate through them with a Next Page and Last Page button at the top and bottom of the page.
getPostsTotal() was added to postManager.js to help with this logic, and display how many total posts are in the db.
The default page is 1 and the default limit is 10.
There is nowhere on the page to change the limit or browse to a specific page, but we can easily add these later.